### PR TITLE
Improve cart theming and controls

### DIFF
--- a/index.html
+++ b/index.html
@@ -68,13 +68,13 @@
     }
 
     [data-theme="dark"] {
-  --bg: #71B069;
-  --text: #ffffff;
-  --card: #71B069;
-  --brand: #ffffff;         /* ❌ Currently set to white */
-  --brand-hover: #f4f4f4;
-  --brand-light: #ffffff30;
-}
+      --bg: #71B069;
+      --text: #ffffff;
+      --card: #f3f9f3;
+      --brand: #71B069;
+      --brand-hover: #5e9557;
+      --brand-light: #ebf5eb;
+    }
 
     body {
       font-family: 'Libre Baskerville', serif;
@@ -443,20 +443,50 @@
 
         cartTableBody.innerHTML += `
           <tr class="border-t border-gray-200 dark:border-gray-600">
-            <td class="py-2">${product.title}</td>
-            <td class="py-2 text-center">${qty}</td>
-            <td class="py-2 text-right">£${unitPrice.toFixed(2)}</td>
-            <td class="py-2 text-right font-semibold">£${lineTotal.toFixed(2)}</td>
+            <td class="py-2 px-2">${product.title}</td>
+            <td class="py-2 px-2 text-center">
+              <div class="flex items-center justify-center space-x-2">
+                <input type="number" min="1" value="${qty}" data-id="${id}" class="w-14 text-center border rounded qty-input" />
+                <button data-id="${id}" class="text-red-500 delete-item">&times;</button>
+              </div>
+            </td>
+            <td class="py-2 px-2 text-right">£${unitPrice.toFixed(2)}</td>
+            <td class="py-2 px-2 text-right font-semibold">£${lineTotal.toFixed(2)}</td>
           </tr>
         `;
       });
 
       cartTableBody.innerHTML += `
         <tr class="border-t-2 border-gray-400 dark:border-gray-500 font-bold">
-          <td colspan="3" class="pt-3 text-right">Total</td>
-          <td class="pt-3 text-right">£${total.toFixed(2)}</td>
+          <td colspan="3" class="pt-3 px-2 text-right">Total</td>
+          <td class="pt-3 px-2 text-right">£${total.toFixed(2)}</td>
         </tr>
       `;
+
+      cartTableBody.querySelectorAll('.qty-input').forEach(input => {
+        input.addEventListener('change', (e) => {
+          const id = e.target.dataset.id;
+          const value = parseInt(e.target.value, 10);
+          if (isNaN(value) || value <= 0) {
+            delete cart[id];
+          } else {
+            cart[id] = value;
+          }
+          localStorage.setItem('cart', JSON.stringify(cart));
+          renderCartTable();
+          updateCartDisplay();
+        });
+      });
+
+      cartTableBody.querySelectorAll('.delete-item').forEach(btn => {
+        btn.addEventListener('click', () => {
+          const id = btn.dataset.id;
+          delete cart[id];
+          localStorage.setItem('cart', JSON.stringify(cart));
+          renderCartTable();
+          updateCartDisplay();
+        });
+      });
     }
 
     viewCartBtn?.addEventListener('click', () => {
@@ -732,7 +762,7 @@
 </div>
 
 <!-- Cart Card -->
-<div id="cartPanel" class="hidden fixed top-[6.5rem] right-4 w-80 max-h-[60%] bg-white dark:bg-[#2a3b2f] shadow-lg rounded-lg z-50 overflow-y-auto">
+<div id="cartPanel" class="hidden fixed top-[6.5rem] right-4 w-96 max-h-[60%] bg-card shadow-lg rounded-lg z-50 overflow-y-auto">
   <div class="p-4 border-b border-gray-300 dark:border-gray-600 flex justify-between items-center">
     <h3 class="text-lg font-bold text-accent-dark dark:text-white">Your Basket</h3>
     <button id="closeCartPanel" class="text-xl font-bold text-gray-700 dark:text-white">&times;</button>
@@ -741,10 +771,10 @@
     <table class="w-full text-sm text-left text-gray-700 dark:text-gray-100">
       <thead>
         <tr class="border-b border-gray-300 dark:border-gray-600">
-          <th class="pb-2">Item</th>
-          <th class="pb-2 text-center">Qty</th>
-          <th class="pb-2 text-right">Unit</th>
-          <th class="pb-2 text-right">Total</th>
+          <th class="pb-2 px-2">Item</th>
+          <th class="pb-2 px-2 text-center">Qty</th>
+          <th class="pb-2 px-2 text-right">Unit</th>
+          <th class="pb-2 px-2 text-right">Total</th>
         </tr>
       </thead>
       <tbody id="cartTableBody"></tbody>


### PR DESCRIPTION
## Summary
- keep brand and card colors consistent across themes
- widen cart, add quantity editing and delete buttons for items

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27a544064832f8696ad49088ae578