### PR TITLE
fix: restore green dark-mode styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -53,7 +53,7 @@
 }
 
   #viewCart svg { color: #000000; }
-  [data-theme="dark"] #viewCart svg { color: #ffffff; }
+  [data-theme="dark"] #viewCart svg { color: #000000; }
 
   
     :root {
@@ -69,8 +69,8 @@
 
     [data-theme="dark"] {
       --bg: #71B069;
-      --text: #ffffff;
-      --card: #f3f9f3;
+      --text: #1f2937;
+      --card: #71B069;
       --brand: #71B069;
       --brand-hover: #5e9557;
       --brand-light: #ebf5eb;
@@ -763,14 +763,14 @@
 
 <!-- Cart Card -->
 <div id="cartPanel" class="hidden fixed top-[6.5rem] right-4 w-96 max-h-[60%] bg-card shadow-lg rounded-lg z-50 overflow-y-auto">
-  <div class="p-4 border-b border-gray-300 dark:border-gray-600 flex justify-between items-center">
-    <h3 class="text-lg font-bold text-accent-dark dark:text-white">Your Basket</h3>
-    <button id="closeCartPanel" class="text-xl font-bold text-gray-700 dark:text-white">&times;</button>
+  <div class="p-4 border-b border-gray-300 flex justify-between items-center">
+    <h3 class="text-lg font-bold text-black">Your Basket</h3>
+    <button id="closeCartPanel" class="text-xl font-bold text-black">&times;</button>
   </div>
   <div class="p-4">
-    <table class="w-full text-sm text-left text-gray-700 dark:text-gray-100">
+    <table class="w-full text-sm text-left text-black">
       <thead>
-        <tr class="border-b border-gray-300 dark:border-gray-600">
+        <tr class="border-b border-gray-300">
           <th class="pb-2 px-2">Item</th>
           <th class="pb-2 px-2 text-center">Qty</th>
           <th class="pb-2 px-2 text-right">Unit</th>


### PR DESCRIPTION
## Summary
- restore green backgrounds and dark text for dark mode
- keep cart panel text readable with black typography

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c27d81fa58832fb6d2b6ccdc3934fe