### PR TITLE
Fix product card theming and cart animations

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,9 +109,26 @@
       color: black;
     }
 	
-	[data-theme="dark"] .product-description p {
-  color: #FDF6E3;
-}
+    .product-description {
+      color: var(--accent-dark);
+    }
+
+    [data-theme="dark"] .product-description {
+      color: #FDF6E3;
+    }
+
+    .ingredients-box {
+      background-color: #fdf6e3;
+      color: var(--accent-dark);
+    }
+
+    [data-theme="dark"] .ingredients-box {
+      color: var(--accent-dark);
+    }
+
+    .ingredients-box strong {
+      color: var(--accent-dark);
+    }
 
 
 #detailPanel {
@@ -281,7 +298,7 @@
         <span id="panelQty" class="text-sm text-brand font-semibold">x1</span>
         <button id="panelAddBtn" class="add-button px-3 py-1 rounded text-sm">Add to Cart</button>
       </div>
-      <div id="detailDescription" class="product-description space-y-4 text-sm text-gray-600 dark:text-white"></div>
+      <div id="detailDescription" class="product-description space-y-4 text-sm"></div>
 <!-- Prevents text from being cut off on iOS Safari -->
 <div style="height: calc(env(safe-area-inset-bottom, 0px) + 80px);"></div>
 
@@ -421,12 +438,9 @@
   // Add "Ingredients" box if present
   if (product.allergens && product.allergens.trim() !== "") {
     descriptionHTML += `
-  <div class="mt-4 px-4 py-3 rounded border border-yellow-300 bg-yellow-50 text-gray-800 dark:border-green-600 dark:bg-[#2a3b2f]">
-    <strong class="block mb-1 text-accent-dark dark:text-white">Ingredients</strong>
-    <p class="text-sm leading-snug" style="color: #1f2937; darkreader-inline-color: #e8e6e3;" data-darkreader-inline-color>
-  ${product.allergens}
-</p>
-
+  <div class="ingredients-box mt-4 px-4 py-3 rounded border border-yellow-300 bg-yellow-50">
+    <strong class="block mb-1">Ingredients</strong>
+    <p class="ingredients-text text-sm leading-snug">${product.allergens}</p>
   </div>
 `;
 
@@ -452,6 +466,8 @@
   panelTrolley.addEventListener('click', () => {
     panelQuantity++;
     panelQty.textContent = `x${panelQuantity}`;
+    panelTrolley.classList.add('shake');
+    panelTrolley.addEventListener('animationend', () => panelTrolley.classList.remove('shake'), { once: true });
   });
 
   panelAddBtn.addEventListener('click', () => {
@@ -462,6 +478,8 @@
     panelQuantity = 1;
     panelQty.textContent = `x${panelQuantity}`;
     updateCartDisplay();
+    panelAddBtn.classList.add('bump');
+    panelAddBtn.addEventListener('animationend', () => panelAddBtn.classList.remove('bump'), { once: true });
   });
   
   document.addEventListener('DOMContentLoaded', () => {
@@ -829,7 +847,7 @@
 <!-- Cart Card -->
 <div id="cartPanel" class="hidden fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 max-h-[60%] bg-card shadow-lg rounded-lg z-[60] overflow-y-auto">
   <div class="p-4 border-b border-gray-300 flex justify-between items-center">
-    <h3 class="text-lg font-bold text-black">Your Basket</h3>
+    <h3 class="text-lg font-bold text-black">Your Cart</h3>
     <button id="closeCartPanel" class="text-xl font-bold text-black">&times;</button>
   </div>
   <div class="p-4">


### PR DESCRIPTION
## Summary
- fix cart panel heading to say Cart
- sync product detail cart animations with main page
- correct theming for product description and ingredients panel

## Testing
- `npm test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68c28812b3e4832fb59507df740045ce