### PR TITLE
Improve product card close button

### DIFF
--- a/index.html
+++ b/index.html
@@ -292,13 +292,14 @@
 
   <!-- Overlay and Slide-Out Panel -->
   <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 hidden z-40"></div>
-  <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out overflow-y-auto">
-    <button id="closePanel" class="absolute top-3 right-4 text-2xl font-bold text-gray-7<button id="closePanel"
-  class="absolute top-3 right-4 text-2xl font-bold text-gray-700 dark:text-white z-10">
-  &times;
-</button>
+  <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out">
+    <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-brand-light text-gray-700 dark:text-white flex items-center justify-center z-10">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+        <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
+      </svg>
+    </button>
 
-    <div class="p-6 w-full max-w-[600px] mx-auto">
+    <div class="p-6 pt-14 w-full max-w-[600px] mx-auto h-full overflow-y-auto">
 
       <img id="detailImage" src="" class="w-full h-auto mb-4 rounded" />
       <h3 id="detailTitle" class="text-2xl font-bold text-accent-dark mb-2"></h3>


### PR DESCRIPTION
## Summary
- enlarge product detail panel close button and use an SVG icon
- keep close button fixed while content scrolls

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c40c07d29c832fb987d89fdd0a81a1