### PR TITLE
Highlight product card close button and add mobile overlay

### DIFF
--- a/index.html
+++ b/index.html
@@ -291,9 +291,9 @@
   </main>
 
   <!-- Overlay and Slide-Out Panel -->
-  <div id="overlay" class="fixed inset-0 bg-black bg-opacity-40 hidden z-40"></div>
+  <div id="overlay" class="fixed inset-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40"></div>
   <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out">
-    <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-brand-light text-gray-700 dark:text-white flex items-center justify-center z-10">
+    <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-red-500 text-white flex items-center justify-center z-10">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
       </svg>


### PR DESCRIPTION
## Summary
- Make the product detail close button red for better visibility
- Use a solid theme-colored overlay on phones to fully obscure the main page when a product is open

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c40daa3d70832fb49db4a735065fae