### PR TITLE
Fix desktop detail panel alignment and text colors

### DIFF
--- a/index.html
+++ b/index.html
@@ -166,6 +166,14 @@
       color: white;
     }
 
+    #detailPrice {
+      color: #374151; /* ensure readable in light theme */
+    }
+
+    [data-theme="dark"] #detailPrice {
+      color: white;
+    }
+
     [data-theme="dark"] #cartPanel {
       background-color: white;
     }
@@ -301,8 +309,8 @@
   </main>
 
   <!-- Overlay and Slide-Out Panel -->
-  <div id="overlay" class="fixed inset-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40"></div>
-  <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out">
+  <div id="overlay" class="fixed top-0 left-0 right-0 bottom-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40 sm:top-[6.5rem]"></div>
+  <div id="detailPanel" class="fixed top-[6.5rem] right-0 md:right-6 lg:right-8 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full md:translate-x-[calc(100%+1.5rem)] lg:translate-x-[calc(100%+2rem)] transition-transform duration-300 ease-in-out">
     <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-red-500 text-white flex items-center justify-center z-10">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
@@ -461,7 +469,7 @@
 
   panelQty.textContent = `x${panelQuantity}`;
   overlay.classList.remove('hidden');
-  panel.classList.remove('translate-x-full');
+  panel.classList.remove('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
   document.body.classList.add('freeze-scroll');
 
   // Description
@@ -485,13 +493,13 @@
 
   closePanel.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    panel.classList.add('translate-x-full');
+    panel.classList.add('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
     document.body.classList.remove('freeze-scroll');
   });
 
   overlay.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    panel.classList.add('translate-x-full');
+    panel.classList.add('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
     document.body.classList.remove('freeze-scroll');
   });
 


### PR DESCRIPTION
## Summary
- Offset desktop product detail panel so it slides in within page padding
- Keep site logo visible when the detail panel is open
- Ensure price text uses readable colors in light and dark themes

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68c41259b428832fbbbabb6432ef4bb2