### PR TITLE
Adjust slide-out detail panel spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -309,8 +309,8 @@
   </main>
 
   <!-- Overlay and Slide-Out Panel -->
-  <div id="overlay" class="fixed top-0 left-0 right-0 bottom-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40 sm:top-[6.5rem]"></div>
-  <div id="detailPanel" class="fixed top-[6.5rem] right-0 md:right-6 lg:right-8 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full md:translate-x-[calc(100%+1.5rem)] lg:translate-x-[calc(100%+2rem)] transition-transform duration-300 ease-in-out">
+  <div id="overlay" class="fixed top-0 left-0 md:left-6 lg:left-8 right-0 bottom-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40 sm:top-[6.5rem]"></div>
+  <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out">
     <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-red-500 text-white flex items-center justify-center z-10">
       <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
@@ -469,7 +469,7 @@
 
   panelQty.textContent = `x${panelQuantity}`;
   overlay.classList.remove('hidden');
-  panel.classList.remove('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
+  panel.classList.remove('translate-x-full');
   document.body.classList.add('freeze-scroll');
 
   // Description
@@ -493,13 +493,13 @@
 
   closePanel.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    panel.classList.add('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
+    panel.classList.add('translate-x-full');
     document.body.classList.remove('freeze-scroll');
   });
 
   overlay.addEventListener('click', () => {
     overlay.classList.add('hidden');
-    panel.classList.add('translate-x-full', 'md:translate-x-[calc(100%+1.5rem)]', 'lg:translate-x-[calc(100%+2rem)]');
+    panel.classList.add('translate-x-full');
     document.body.classList.remove('freeze-scroll');
   });
 


### PR DESCRIPTION
## Summary
- Align overlay with page padding on larger screens so left side stays visible
- Remove right margin and extra transforms so the detail panel sits flush on desktop
- Simplify JS to toggle a single translate class for panel transitions

## Testing
- `npm test` *(fails: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e058c518832fb4ad4647bca46f3f