### PR TITLE
Fix slide-out panel close button spacing and size

### DIFF
--- a/index.html
+++ b/index.html
@@ -311,8 +311,8 @@
   <!-- Overlay and Slide-Out Panel -->
   <div id="overlay" class="fixed top-0 left-0 md:left-6 lg:left-8 right-0 bottom-0 hidden z-40 bg-[var(--bg)] sm:bg-black sm:bg-opacity-40 sm:top-[6.5rem]"></div>
   <div id="detailPanel" class="fixed top-[6.5rem] right-0 w-full sm:w-[400px] h-full bg-card z-50 shadow-lg transform translate-x-full transition-transform duration-300 ease-in-out">
-    <button id="closePanel" class="absolute top-4 right-4 w-10 h-10 rounded-full bg-red-500 text-white flex items-center justify-center z-10">
-      <svg xmlns="http://www.w3.org/2000/svg" class="w-6 h-6" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
+    <button id="closePanel" class="absolute top-0 right-0 w-8 h-8 rounded-full bg-red-500 text-white flex items-center justify-center z-10">
+      <svg xmlns="http://www.w3.org/2000/svg" class="w-5 h-5" fill="none" viewBox="0 0 24 24" stroke="currentColor" stroke-width="2">
         <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12"/>
       </svg>
     </button>


### PR DESCRIPTION
## Summary
- Remove gap at top of slide-out detail panel by aligning close button with panel edge
- Shrink close button for a more balanced appearance

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_68c7e2a04290832fa832c3c607d93ac3