### PR TITLE
Align desktop font weight with mobile styling

### DIFF
--- a/index.html
+++ b/index.html
@@ -284,7 +284,7 @@
 
 
   <!-- Category Navigation -->
-  <nav class="sticky top-[6.5rem] z-40 bg-card p-2 flex gap-4 text-sm font-semibold border-b border-gray-200" id="categoryNav">
+  <nav class="sticky top-[6.5rem] z-40 bg-card p-2 flex gap-4 text-sm border-b border-gray-200" id="categoryNav">
     <a href="#" data-category="HairCare" class="text-brand hover:underline">Hair Care</a>
     <a href="#" data-category="SkinCare" class="text-brand hover:underline">Skin Care</a>
     <a href="#" data-category="Accessories" class="text-brand hover:underline">Accessories</a>
@@ -295,19 +295,19 @@
   <!-- Main Content -->
   <main class="p-4 space-y-12">
     <section id="HairCare">
-      <h3 class="text-2xl font-semibold mb-4 border-b-2 border-brand text-accent-dark inline-block">Hair Care</h3>
+      <h3 class="text-2xl mb-4 border-b-2 border-brand text-accent-dark inline-block">Hair Care</h3>
       <div class="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" id="freshGrid"></div>
     </section>
     <section id="SkinCare">
-      <h3 class="text-2xl font-semibold mb-4 border-b-2 border-brand text-accent-dark inline-block">Skin Care</h3>
+      <h3 class="text-2xl mb-4 border-b-2 border-brand text-accent-dark inline-block">Skin Care</h3>
       <div class="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" id="pantryGrid"></div>
     </section>
     <section id="Accessories">
-      <h3 class="text-2xl font-semibold mb-4 border-b-2 border-brand text-accent-dark inline-block">Accessories</h3>
+      <h3 class="text-2xl mb-4 border-b-2 border-brand text-accent-dark inline-block">Accessories</h3>
       <div class="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" id="drinksGrid"></div>
     </section>
     <section id="Bundles">
-      <h3 class="text-2xl font-semibold mb-4 border-b-2 border-brand text-accent-dark inline-block">Bundles</h3>
+      <h3 class="text-2xl mb-4 border-b-2 border-brand text-accent-dark inline-block">Bundles</h3>
       <div class="grid gap-4 grid-cols-2 sm:grid-cols-3 md:grid-cols-4 lg:grid-cols-5" id="householdGrid"></div>
     </section>
   </main>
@@ -324,7 +324,7 @@
     <div class="p-6 pt-0 w-full max-w-[600px] mx-auto h-full overflow-y-auto">
 
       <img id="detailImage" src="" class="w-full h-auto mb-4 rounded" />
-      <h3 id="detailTitle" class="text-2xl font-bold text-accent-dark mb-2"></h3>
+      <h3 id="detailTitle" class="text-2xl text-accent-dark mb-2"></h3>
       <p id="detailPrice" class="text-gray-700 dark:text-white text-lg mb-4"></p>
       <div class="flex items-center gap-3 mb-4">
         <button id="panelTrolley" class="trolley-button" title="Increase Quantity">
@@ -339,7 +339,7 @@
           </svg>
                   </span>
         </button>
-        <span id="panelQty" class="text-sm text-brand font-semibold">x1</span>
+        <span id="panelQty" class="text-sm text-brand">x1</span>
         <button id="panelAddBtn" class="add-button px-3 py-1 rounded text-sm">Add to Cart</button>
       </div>
       <div id="detailDescription" class="product-description space-y-4 text-sm"></div>
@@ -423,7 +423,7 @@
 
       card.innerHTML = `
         <img src="${product.image_urls}" alt="${product.title}" class="w-full h-auto mb-2 rounded cursor-pointer"/>
-        <h3 class="font-semibold text-lg text-accent-dark">
+        <h3 class="text-lg text-accent-dark">
   ${product.title}
   ${product.size ? `<span class="unit-text text-sm"> (${product.size})</span>` : ''}
 </h3>
@@ -440,7 +440,7 @@
               </svg>
             </span>
           </button>
-          <span class="product-qty text-sm text-brand font-semibold" id="qty-${product.id}">x1</span>
+          <span class="product-qty text-sm text-brand" id="qty-${product.id}">x1</span>
           <button class="product-add add-button px-2 py-1 rounded text-xs sm:text-sm whitespace-nowrap" data-id="${product.id}">
             Add to Cart
           </button>
@@ -568,13 +568,13 @@
               </div>
             </td>
             <td class="py-2 px-2 text-right">£${unitPrice.toFixed(2)}</td>
-            <td class="py-2 px-2 text-right font-semibold">£${lineTotal.toFixed(2)}</td>
+            <td class="py-2 px-2 text-right">£${lineTotal.toFixed(2)}</td>
           </tr>
         `;
       });
 
       cartTableBody.innerHTML += `
-        <tr class="border-t-2 border-gray-400 dark:border-gray-500 font-bold">
+        <tr class="border-t-2 border-gray-400 dark:border-gray-500">
           <td colspan="3" class="pt-3 px-2 text-right">Total</td>
           <td class="pt-3 px-2 text-right">£${total.toFixed(2)}</td>
         </tr>
@@ -859,7 +859,7 @@
 <!-- Contact Modal -->
 <div id="contactModal" class="fixed inset-0 bg-black bg-opacity-60 flex items-center justify-center z-50 hidden">
   <div class="bg-white dark:bg-[#333] rounded-lg max-w-md w-full p-6 relative">
-    <button id="closeContactModal" class="absolute top-2 right-2 text-2xl font-bold text-gray-700 dark:text-white">&times;</button>
+    <button id="closeContactModal" class="absolute top-2 right-2 text-2xl text-gray-700 dark:text-white">&times;</button>
     
     <p class="mb-4 text-sm text-gray-700 dark:text-gray-100">
       Interested in working together? Fill out some info and we will be in touch shortly. We can’t wait to hear from you!
@@ -902,8 +902,8 @@
 <!-- Cart Card -->
 <div id="cartPanel" class="hidden fixed top-1/2 left-1/2 transform -translate-x-1/2 -translate-y-1/2 w-96 max-h-[60%] bg-card shadow-lg rounded-lg z-[60] overflow-y-auto">
   <div class="p-4 border-b border-gray-300 flex justify-between items-center">
-    <h3 class="text-lg font-bold text-black">Your Cart</h3>
-    <button id="closeCartPanel" class="text-xl font-bold text-black">&times;</button>
+    <h3 class="text-lg text-black">Your Cart</h3>
+    <button id="closeCartPanel" class="text-xl text-black">&times;</button>
   </div>
   <div class="p-4">
     <table class="w-full text-sm text-left text-black">


### PR DESCRIPTION
## Summary
- remove bold font classes from navigation and section headings
- normalize font weight in product details, cart summaries and modal controls

## Testing
- `npm test` (fails: Error: no test specified)


------
https://chatgpt.com/codex/tasks/task_e_68c7e8b6b790832f95d73cbb7e0ff469